### PR TITLE
[SUPESC-301] Make CrefoPay work without Silex (with Router plugin)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
-dist: trusty
+os: linux
+dist: bionic
 
 notifications:
   email: false
@@ -9,29 +10,42 @@ sudo: required
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
+    - php: 7.3
       env:
         - PRODUCT_NAME=suite
 
-    - php: 7.2
+    - php: 7.3
       env:
         - PRODUCT_NAME=b2c-demo-shop
 
-    - php: 7.2
+    - php: 7.3
       env:
         - PRODUCT_NAME=b2b-demo-shop
 
 services:
   - postgresql
-  - redis-server
+  - redis
   - rabbitmq
 
 addons:
-  postgresql: 9.4
+  postgresql: "12"
 
   apt:
+    sources:
+      - sourceline: ppa:chris-lea/redis-server
+      - sourceline: deb http://dl.bintray.com/rabbitmq-erlang/debian bionic erlang
+        key_url: https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
+      - sourceline: deb https://dl.bintray.com/rabbitmq/debian bionic main
+        key_url: https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
+      - sourceline: ppa:ondrej/php
     packages:
+      - redis-tools
+      - redis-server
+      - rabbitmq-server
       - graphviz
+      - postgresql-12
+      - postgresql-client-12
+      - postgresql-server-dev-12
 
   hosts:
     - zed.de.spryker.test
@@ -39,12 +53,13 @@ addons:
 
 env:
   global:
-    - APPLICATION_ENV=devtest
+    - APPLICATION_ENV=ci.pgsql
+    - SPRYKER_TESTING_ENABLED=1
     - APPLICATION_STORE=DE
     - MODULE_DIR=module
     - SHOP_DIR=current
     - MODULE_NAME=crefo-pay
-    - POSTGRES_PORT=5432
+    - POSTGRES_PORT=5433
 
 cache:
   directories:
@@ -56,5 +71,5 @@ before_install:
   - phpenv config-rm xdebug.ini
 
 script:
-  - git clone -b 0.3.0 https://github.com/spryker-eco/eco-ci.git ecoci
+  - git clone -b bugfix/spryker-shop-suite-contains-no-ci-scripts --single-branch https://github.com/spryker-eco/eco-ci.git ecoci
   - ./ecoci/build/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,5 +56,5 @@ before_install:
   - phpenv config-rm xdebug.ini
 
 script:
-  - git clone -b 0.3.0 https://github.com/spryker-eco/eco-ci.git ecoci
+  - git clone -b bugfix/spryker-shop-suite-contains-no-ci-scripts --single-branch https://github.com/spryker-eco/eco-ci.git ecoci
   - ./ecoci/build/travis.sh

--- a/src/SprykerEco/Shared/CrefoPay/CrefoPayConfig.php
+++ b/src/SprykerEco/Shared/CrefoPay/CrefoPayConfig.php
@@ -39,6 +39,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     protected const EXTERNAL_PAYMENT_METHOD_CREDIT_CARD_3D = 'CC3D';
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getProviderName(): string
@@ -47,6 +49,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return int
      */
     public function getUserRiskClass(): int
@@ -55,6 +59,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getProductTypeDefault(): string
@@ -63,6 +69,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getProductTypeShippingCosts(): string
@@ -71,6 +79,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return int
      */
     public function getProductRiskClass(): int
@@ -79,6 +89,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getExternalPaymentMethodBill(): string
@@ -87,6 +99,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getExternalPaymentMethodCashOnDelivery(): string
@@ -95,6 +109,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getExternalPaymentMethodDirectDebit(): string
@@ -103,6 +119,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getExternalPaymentMethodPayPal(): string
@@ -111,6 +129,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getExternalPaymentMethodPrepaid(): string
@@ -119,6 +139,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getExternalPaymentMethodSofort(): string
@@ -127,6 +149,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getExternalPaymentMethodCreditCard(): string
@@ -135,6 +159,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getExternalPaymentMethodCreditCard3D(): string
@@ -143,6 +169,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getCrefoPayPaymentMethodBill(): string
@@ -151,6 +179,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getCrefoPayPaymentMethodCashOnDelivery(): string
@@ -159,6 +189,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getCrefoPayPaymentMethodDirectDebit(): string
@@ -167,6 +199,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getCrefoPayPaymentMethodPayPal(): string
@@ -175,6 +209,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getCrefoPayPaymentMethodPrepaid(): string
@@ -183,6 +219,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getCrefoPayPaymentMethodSofort(): string
@@ -191,6 +229,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getCrefoPayPaymentMethodCreditCard(): string
@@ -199,6 +239,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getCrefoPayPaymentMethodCreditCard3D(): string

--- a/src/SprykerEco/Yves/CrefoPay/CrefoPayConfig.php
+++ b/src/SprykerEco/Yves/CrefoPay/CrefoPayConfig.php
@@ -14,6 +14,8 @@ use SprykerEco\Shared\CrefoPayApi\CrefoPayApiConstants;
 class CrefoPayConfig extends AbstractBundleConfig
 {
     /**
+     * @api
+     *
      * @return string
      */
     public function getPublicKey(): string
@@ -22,6 +24,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getSecureFieldsApiEndpoint(): string
@@ -30,6 +34,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string[]
      */
     public function getSecureFieldsPlaceholders(): array

--- a/src/SprykerEco/Yves/CrefoPay/Plugin/Provider/CrefoPayControllerProvider.php
+++ b/src/SprykerEco/Yves/CrefoPay/Plugin/Provider/CrefoPayControllerProvider.php
@@ -10,6 +10,9 @@ namespace SprykerEco\Yves\CrefoPay\Plugin\Provider;
 use Silex\Application;
 use SprykerShop\Yves\ShopApplication\Plugin\Provider\AbstractYvesControllerProvider;
 
+/**
+ * @deprecated Use {@link \SprykerEco\Yves\CrefoPay\Plugin\Router\CrefoPayRouteProviderPlugin} instead.
+ */
 class CrefoPayControllerProvider extends AbstractYvesControllerProvider
 {
     protected const BUNDLE_NAME = 'CrefoPay';

--- a/src/SprykerEco/Yves/CrefoPay/Plugin/Router/CrefoPayRouteProviderPlugin.php
+++ b/src/SprykerEco/Yves/CrefoPay/Plugin/Router/CrefoPayRouteProviderPlugin.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace SprykerEco\Yves\CrefoPay\Plugin\Router;
+
+use Spryker\Yves\Router\Plugin\RouteProvider\AbstractRouteProviderPlugin;
+use Spryker\Yves\Router\Route\RouteCollection;
+
+class CrefoPayRouteProviderPlugin extends AbstractRouteProviderPlugin
+{
+    protected const BUNDLE_NAME = 'CrefoPay';
+    protected const CALLBACK_CONTROLLER_NAME = 'Callback';
+    protected const NOTIFICATION_CONTROLLER_NAME = 'Notification';
+    protected const CREFO_PAY_NOTIFICATION = 'crefo-pay-notification';
+    protected const CREFO_PAY_CONFIRMATION = 'crefo-pay-confirmation';
+    protected const CREFO_PAY_SUCCESS = 'crefo-pay-success';
+    protected const CREFO_PAY_FAILURE = 'crefo-pay-failure';
+
+    /**
+     * @param \Spryker\Yves\Router\Route\RouteCollection $routeCollection
+     *
+     * @return \Spryker\Yves\Router\Route\RouteCollection
+     */
+    public function addRoutes(RouteCollection $routeCollection): RouteCollection
+    {
+        $routeCollection = $this->addCrefoPayNotificationRoute($routeCollection);
+        $routeCollection = $this->addCrefoPayConfirmationRoute($routeCollection);
+        $routeCollection = $this->addCrefoPaySuccessRoute($routeCollection);
+        $routeCollection = $this->addCrefoPayFailureRoute($routeCollection);
+
+        return $routeCollection;
+    }
+
+    /**
+     * @param \Spryker\Yves\Router\Route\RouteCollection $routeCollection
+     *
+     * @return \Spryker\Yves\Router\Route\RouteCollection
+     */
+    protected function addCrefoPayNotificationRoute(RouteCollection $routeCollection): RouteCollection
+    {
+        $routeCollection->add(
+            static::CREFO_PAY_NOTIFICATION,
+            $this->buildPostRoute('/crefo-pay/notification', static::BUNDLE_NAME, static::NOTIFICATION_CONTROLLER_NAME, 'index')
+        );
+
+        return $routeCollection;
+    }
+
+    /**
+     * @param \Spryker\Yves\Router\Route\RouteCollection $routeCollection
+     *
+     * @return \Spryker\Yves\Router\Route\RouteCollection
+     */
+    protected function addCrefoPayConfirmationRoute(RouteCollection $routeCollection): RouteCollection
+    {
+        $routeCollection->add(
+            static::CREFO_PAY_CONFIRMATION,
+            $this->buildPostRoute('/crefo-pay/callback/confirmation', static::BUNDLE_NAME, static::CALLBACK_CONTROLLER_NAME, 'confirmation')
+        );
+
+        return $routeCollection;
+    }
+
+    /**
+     * @param \Spryker\Yves\Router\Route\RouteCollection $routeCollection
+     *
+     * @return \Spryker\Yves\Router\Route\RouteCollection
+     */
+    protected function addCrefoPaySuccessRoute(RouteCollection $routeCollection): RouteCollection
+    {
+        $routeCollection->add(
+            static::CREFO_PAY_SUCCESS,
+            $this->buildPostRoute('/crefo-pay/callback/success', static::BUNDLE_NAME, static::CALLBACK_CONTROLLER_NAME, 'success')
+        );
+
+        return $routeCollection;
+    }
+
+    /**
+     * @param \Spryker\Yves\Router\Route\RouteCollection $routeCollection
+     *
+     * @return \Spryker\Yves\Router\Route\RouteCollection
+     */
+    protected function addCrefoPayFailureRoute(RouteCollection $routeCollection): RouteCollection
+    {
+        $routeCollection->add(
+            static::CREFO_PAY_FAILURE,
+            $this->buildPostRoute('/crefo-pay/callback/failure', static::BUNDLE_NAME, static::CALLBACK_CONTROLLER_NAME, 'failure')
+        );
+
+        return $routeCollection;
+    }
+}

--- a/src/SprykerEco/Zed/CrefoPay/Business/Oms/Command/CaptureOmsCommand.php
+++ b/src/SprykerEco/Zed/CrefoPay/Business/Oms/Command/CaptureOmsCommand.php
@@ -18,7 +18,8 @@ class CaptureOmsCommand extends CrefoPayOmsCommandByOrder implements CrefoPayOms
      */
     protected function performApiCall(CrefoPayOmsCommandTransfer $crefoPayOmsCommandTransfer): CrefoPayOmsCommandTransfer
     {
-        if ($crefoPayOmsCommandTransfer->getPaymentCrefoPay()->getCapturedAmount() === 0
+        if (
+            $crefoPayOmsCommandTransfer->getPaymentCrefoPay()->getCapturedAmount() === 0
             && $crefoPayOmsCommandTransfer->getExpensesRequest() !== null
         ) {
             $expensesResponseTransfer = $this->omsCommandClient

--- a/src/SprykerEco/Zed/CrefoPay/CrefoPayConfig.php
+++ b/src/SprykerEco/Zed/CrefoPay/CrefoPayConfig.php
@@ -56,6 +56,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     protected const CREFO_PAY_AUTOMATIC_OMS_TRIGGER = 'CREFO_PAY_AUTOMATIC_OMS_TRIGGER';
 
     /**
+     * @api
+     *
      * @return int
      */
     public function getMerchantId(): int
@@ -64,6 +66,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getStoreId(): string
@@ -72,6 +76,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getRefundDescription(): string
@@ -80,6 +86,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getProviderName(): string
@@ -88,6 +96,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return int
      */
     public function getUserRiskClass(): int
@@ -96,6 +106,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getProductTypeDefault(): string
@@ -104,6 +116,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getProductTypeShippingCosts(): string
@@ -112,6 +126,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return int
      */
     public function getProductRiskClass(): int
@@ -120,6 +136,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string[]
      */
     public function getInternalToExternalPaymentMethodNamesMapping(): array
@@ -137,6 +155,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getNotificationTransactionStatusAcknowledgePending(): string
@@ -145,6 +165,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getNotificationTransactionStatusMerchantPending(): string
@@ -153,6 +175,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getNotificationTransactionStatusCiaPending(): string
@@ -161,6 +185,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getNotificationTransactionStatusCancelled(): string
@@ -169,6 +195,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getNotificationTransactionStatusExpired(): string
@@ -177,6 +205,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getNotificationTransactionStatusDone(): string
@@ -185,6 +215,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getNotificationOrderStatusPayPending(): string
@@ -193,6 +225,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getNotificationOrderStatusPaid(): string
@@ -201,6 +235,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getNotificationOrderStatusChargeBack(): string
@@ -209,6 +245,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusNew(): string
@@ -217,6 +255,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusReserved(): string
@@ -225,6 +265,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusAuthorized(): string
@@ -233,6 +275,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusWaitingForCapture(): string
@@ -241,6 +285,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusWaitingForCash(): string
@@ -249,6 +295,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusCapturePending(): string
@@ -257,6 +305,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusCaptured(): string
@@ -265,6 +315,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusCancellationPending(): string
@@ -273,6 +325,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusCanceled(): string
@@ -281,6 +335,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusRefunded(): string
@@ -289,6 +345,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusMoneyReduced(): string
@@ -297,6 +355,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusExpired(): string
@@ -305,6 +365,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsStatusDone(): string
@@ -313,6 +375,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsEventCancel(): string
@@ -321,6 +385,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsEventNoCancellation(): string
@@ -329,6 +395,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getOmsEventFinish(): string
@@ -337,6 +405,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string[]
      */
     public function getNotificationTransactionToOmsStatusMapping(): array
@@ -352,6 +422,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string[]
      */
     public function getNotificationOrderToOmsStatusMapping(): array
@@ -364,6 +436,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return int
      */
     public function getCrefoPayApiCaptureIdLength(): int
@@ -372,6 +446,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getCrefoPayAutomaticOmsTrigger(): string
@@ -380,6 +456,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return bool
      */
     public function getIsBusinessToBusiness(): bool
@@ -388,6 +466,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return bool
      */
     public function getCaptureExpensesSeparately(): bool
@@ -396,6 +476,8 @@ class CrefoPayConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return bool
      */
     public function getRefundExpensesWithLastItem(): bool


### PR DESCRIPTION
- Developer(s): @boykodev

- Ticket: https://spryker.atlassian.net/browse/SUPESC-301

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/3330

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CrefoPay              | major                 |                       |

-----------------------------------------

#### Module CrefoPay

##### Change log

Improvements

- Make CrefoPay compatible usage without Silex
- Introduced `CrefoPayRouteProviderPlugin`
- Deprecated `CrefoPayControllerProvider`